### PR TITLE
docs(rag): add TODO for short-query cosine fallback

### DIFF
--- a/lib/rag.ts
+++ b/lib/rag.ts
@@ -309,3 +309,5 @@ export function getRAGStats(): RAGStats {
     sourceBreakdown,
   };
 }
+
+// TODO: add cosine similarity fallback for short queries under 3 tokens


### PR DESCRIPTION
BM25 ranking degrades on 1-2 token queries. Notes a future cosine similarity fallback on title embeddings. No functional change.