### PR TITLE
docs(storage): add TODO for IndexedDB key eviction policy

### DIFF
--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -332,3 +332,4 @@ export function generateChatTitle(firstMessage: string): string {
   const cleaned = firstMessage.trim().slice(0, 50);
   return cleaned.length < firstMessage.length ? cleaned + '...' : cleaned;
 }
+// TODO: add IndexedDB eviction policy for keys older than 90 days


### PR DESCRIPTION
Notes that client-side AES keys currently persist indefinitely. A future 90-day TTL would prevent unbounded storage growth. No functional change.